### PR TITLE
Ignore movies without imdb referenced in Trakt

### DIFF
--- a/radarr_sonarr_watchmon.py
+++ b/radarr_sonarr_watchmon.py
@@ -86,8 +86,11 @@ class watchedMonitor(object):
             print(" Trakt: movies watches in last "+str(recent_days)+" days:")
             for movie in Trakt['sync/history'].movies(start_at=recent_date, pagination=True):
                 movie_dict = movie.to_dict()
-                movies_watched_recently_imdbids.append(movie_dict['ids']['imdb'])
-                print("  "+movie_dict['title'])
+                try:
+                    movies_watched_recently_imdbids.append(movie_dict['ids']['imdb'])
+                    print("  "+movie_dict['title'])
+                except KeyError:
+                    pass
 
         return movies_watched_recently_imdbids
 


### PR DESCRIPTION
Sometimes Trakt doesn't store the imdb ID for a given movie, which can result in a crash
In that case we simply don't handle it