### PR TITLE
Better error log + fix Radarr integration

### DIFF
--- a/radarr_sonarr_watchmon.py
+++ b/radarr_sonarr_watchmon.py
@@ -218,7 +218,7 @@ class watchedMonitor(object):
                                 sonarr_episode_json["monitored"] = "False"
                                 r = requests.put(request_uri, json=sonarr_episode_json)
                                 if r.status_code != 202:
-                                   print("   Error: "+str(r.json()["message"))
+                                   print("   Error: "+str(r.json()["message"]))
 
     def medusa(self, recent_days, medusa_address, medusa_username, medusa_password):
 

--- a/radarr_sonarr_watchmon.py
+++ b/radarr_sonarr_watchmon.py
@@ -123,7 +123,7 @@ class watchedMonitor(object):
                     print("  "+movie["title"])
                     radarr_id = movie["id"]
                     movie_json = movie
-                    movie_json["monitored"] = "False"
+                    movie_json["monitored"] = False
                     request_uri ='http://'+radarr_address+'/api/movie?apikey='+radarr_apikey
                     r = requests.put(request_uri, json=movie_json)
                     if r.status_code != 202:
@@ -215,7 +215,7 @@ class watchedMonitor(object):
                                 sonarr_episode_json = requests.get(request_uri).json()
 
                                 # Update sonarr episode
-                                sonarr_episode_json["monitored"] = "False"
+                                sonarr_episode_json["monitored"] = False
                                 r = requests.put(request_uri, json=sonarr_episode_json)
                                 if r.status_code != 202:
                                    print("   Error: "+str(r.json()["message"]))

--- a/radarr_sonarr_watchmon.py
+++ b/radarr_sonarr_watchmon.py
@@ -126,6 +126,8 @@ class watchedMonitor(object):
                     movie_json["monitored"] = "False"
                     request_uri ='http://'+radarr_address+'/api/movie?apikey='+radarr_apikey
                     r = requests.put(request_uri, json=movie_json)
+                    if r.status_code != 202:
+                        print("   Error: "+str(r.json()["message"]))
 
 
     def trakt_get_episodes(self, recent_days):
@@ -215,6 +217,8 @@ class watchedMonitor(object):
                                 # Update sonarr episode
                                 sonarr_episode_json["monitored"] = "False"
                                 r = requests.put(request_uri, json=sonarr_episode_json)
+                                if r.status_code != 202:
+                                   print("   Error: "+str(r.json()["message"))
 
     def medusa(self, recent_days, medusa_address, medusa_username, medusa_password):
 


### PR DESCRIPTION
I noticed that Radarr integration has silently failed for a while now, although nothing shows up in the log. 
Turns out Radarr API now wants "monitored" to be boolean and doesn't accept it as a string anymore.
`BadRequest: Invalid request body. The JSON value could not be converted to System.Boolean. Path: $.monitored | LineNumber: 0 | BytePositionInLine: 1870.`
I fixed this for Radarr and anticipated a fix for Sonarr. Also took the occasion to show the error message when the API doesn't accept the request.